### PR TITLE
Fix inconsistency in greedy postprocessing

### DIFF
--- a/split/src/split/SPLIT.py
+++ b/split/src/split/SPLIT.py
@@ -148,7 +148,7 @@ class SPLIT:
             proportion_of_examples_in_right_leaf = (np.sum(X_train.iloc[:, feature] == 0) / len(X_train))
             gain = entropy_original - ( proportion_of_examples_in_left_leaf* entropy_left +
                                         proportion_of_examples_in_right_leaf* entropy_right)
-            if gain >= max_gain:
+            if gain > max_gain:
                 max_gain = gain
                 best_feature = feature
 


### PR DESCRIPTION
When SPLIT is run with greedy postprocessing, there was a slight inconsistency in the tie-breaking for equivalent information gain splits; the C++ code used during the initial run takes the leftmost split in this case, but our python wrapper to recreate the tree takes the rightmost split.